### PR TITLE
Fix tests for new version of keyring

### DIFF
--- a/R/gateway_keyring.R
+++ b/R/gateway_keyring.R
@@ -110,18 +110,23 @@ get_env_secret <- function(secret) {
 }
 
 get_keyring_secret <- function(secret) {
-  tryCatch(
-    expr = {
-      value <- keyring::key_get(service = "air-rpkg", username = secret)
-      result::success(value, "success")
-    },
-    error = function(cond) {
-      result::failure(cond, "error")
-    },
-    warning = function(cond) {
-      result::success(value, "warn")
+  value <- NULL
+  warned <- FALSE
+  tryCatch({
+    withCallingHandlers(
+      expr = {
+        value <<- keyring::key_get(service = "air-rpkg", username = secret)
+      },
+      warning = function(cond) warned <<- TRUE
+    )
+    if (!warned) {
+      result::success("success", value)
+    } else {
+      result::success("warning", value)
     }
-  )
+  }, error = function(cond) {
+    result::failure("error", cond)
+  })
 }
 
 set_keyring_secret <- function(secret, value = NULL) {

--- a/tests/testthat/test-credentials.R
+++ b/tests/testthat/test-credentials.R
@@ -20,7 +20,9 @@ test_that("BAD: catches an missing API key", {
 
     with_stubbed_credentials({
       Sys.unsetenv("OPENAI_KEY")
-      air::howto("How do I get the first element of a list?")
+      suppressWarnings(
+        air::howto("How do I get the first element of a list?")
+      )
     })
   }
 


### PR DESCRIPTION
The problem with your pattern at 
```r
  tryCatch(
    expr = {
      value <- keyring::key_get(service = "air-rpkg", username = secret)
      success("success", value)
    },
    error = function(cond) {
      failure("error", cond)
    },
    warning = function(cond) {
      success("warn", value)
    }
  )
```
is that if the code in `expr` throws a warning first, and then an error, your code already exits after the warning, and `value` is never set.

The new version of keyring, about to go on CRAN does throw a warning more often than the previous one, e.g. it throws one on CRAN now, and that now makes your test case fail.

I also added a `suppressWarnings()` to your test case, this is not strictly needed.

All this said, I added a special case for the air package in keyring, so you don't need to urgently update your package on CRAN.