### PR TITLE
Update for dev vcr

### DIFF
--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -8,6 +8,4 @@ with_stubbed_credentials({
     ),
     dir = vcr::vcr_test_path("fixtures")
   ))
-
-  vcr::check_cassette_names()
 })


### PR DESCRIPTION
We're about to submit a new version of vcr and there's some changes to be aware of

`vcr::check_cassette_names` is deprecated, so I've removed that

I'd recommend re-recording your fixtures with the new vcr.